### PR TITLE
Config object values

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Create a new instance of MapConfig with a specified map and application.
 var mapper = new MapConfig(app, map);
 ```
 
-### [.map](index.js#L59)
+### [.map](index.js#L61)
 
 Map a properties to methods and/or functions.
 
@@ -50,7 +50,7 @@ mapper
   });
 ```
 
-### [.alias](index.js#L90)
+### [.alias](index.js#L92)
 
 Alias properties to methods on the `app`.
 
@@ -66,7 +66,7 @@ Alias properties to methods on the `app`.
 mapper.alias('foo', 'bar');
 ```
 
-### [.process](index.js#L106)
+### [.process](index.js#L108)
 
 Process a configuration object with the already configured `map` and `app`.
 
@@ -80,7 +80,7 @@ Process a configuration object with the already configured `map` and `app`.
 mapper.process(config);
 ```
 
-### [.addKey](index.js#L151)
+### [.addKey](index.js#L153)
 
 Add a key to the `.keys` array. May also be used to add an array of namespaced keys to the `.keys` array. This is useful for mapping sub configs to a key in a parent config.
 

--- a/README.md
+++ b/README.md
@@ -35,33 +35,19 @@ var mapper = new MapConfig(app, map);
 
 Add a key to the `.keys` array. May also be used to add an array of namespaced keys to the `.keys` array. This is useful for mapping sub configs to a key in a parent config.
 
-```
-var mapper1 = new MapConfig();
-var mapper2 = new MapConfig();
-mapper2.map('foo');
-mapper2.map('bar');
-mapper2.map('baz');
-mapper1.map('mapper2', function(config) {
-  mapper2.process(config);
-});
-mapper1.addKey('mapper2', mapper2.keys);
-```
-
 **Params**
 
 * `key` **{String}**: key to push onto `.keys`
 * `arr` **{Array}**: Array of sub keys to push onto `.keys`
 * `returns` **{Object}** `this`: for chaining
 
-**Examples**
+**Example**
 
 ```js
 mapper.addKey('foo');
 console.log(mapper.keys);
 //=> ['foo']
-```
 
-```
 var mapper1 = new MapConfig();
 var mapper2 = new MapConfig();
 mapper2.map('foo');
@@ -72,6 +58,8 @@ mapper1.map('mapper2', function(config) {
   mapper2.process(config);
 });
 mapper1.addKey('mapper2', mapper2.keys);
+console.log(mapper1.keys);
+//=> ['mapper2.foo', 'mapper2.bar', 'mapper2.baz']
 ```
 
 ### [.map](index.js#L112)
@@ -81,7 +69,7 @@ Map a properties to methods and/or functions.
 **Params**
 
 * `key` **{String}**: property key to map.
-* `fn` **{Function}**: Optional function to call when a config has the given key.
+* `val` **{Function|Object}**: Optional function to call when a config has the given key. May also pass another instance of MapConfig to be processed.
 * `returns` **{Object}** `this`: to enable chaining
 
 **Example**

--- a/README.md
+++ b/README.md
@@ -31,7 +31,56 @@ Create a new instance of MapConfig with a specified map and application.
 var mapper = new MapConfig(app, map);
 ```
 
-### [.addKey](index.js#L72)
+### [.map](index.js#L59)
+
+Map a properties to methods and/or functions.
+
+**Params**
+
+* `key` **{String}**: property key to map.
+* `val` **{Function|Object}**: Optional function to call when a config has the given key. May also pass another instance of MapConfig to be processed.
+* `returns` **{Object}** `this`: to enable chaining
+
+**Example**
+
+```js
+mapper
+  .map('baz')
+  .map('bang', function(config) {
+  });
+```
+
+### [.alias](index.js#L90)
+
+Alias properties to methods on the `app`.
+
+**Params**
+
+* `alias` **{String}**: Property being mapped from..
+* `key` **{String}**: Property being mapped to on the app.
+* `returns` **{Object}** `this`: to enable chaining
+
+**Example**
+
+```js
+mapper.alias('foo', 'bar');
+```
+
+### [.process](index.js#L106)
+
+Process a configuration object with the already configured `map` and `app`.
+
+**Params**
+
+* `config` **{Object}**: Configuration object to map to application methods.
+
+**Example**
+
+```js
+mapper.process(config);
+```
+
+### [.addKey](index.js#L151)
 
 Add a key to the `.keys` array. May also be used to add an array of namespaced keys to the `.keys` array. This is useful for mapping sub configs to a key in a parent config.
 
@@ -60,55 +109,6 @@ mapper1.map('mapper2', function(config) {
 mapper1.addKey('mapper2', mapper2.keys);
 console.log(mapper1.keys);
 //=> ['mapper2.foo', 'mapper2.bar', 'mapper2.baz']
-```
-
-### [.map](index.js#L112)
-
-Map a properties to methods and/or functions.
-
-**Params**
-
-* `key` **{String}**: property key to map.
-* `val` **{Function|Object}**: Optional function to call when a config has the given key. May also pass another instance of MapConfig to be processed.
-* `returns` **{Object}** `this`: to enable chaining
-
-**Example**
-
-```js
-mapper
-  .map('baz')
-  .map('bang', function(config) {
-  });
-```
-
-### [.alias](index.js#L143)
-
-Alias properties to methods on the `app`.
-
-**Params**
-
-* `alias` **{String}**: Property being mapped from..
-* `key` **{String}**: Property being mapped to on the app.
-* `returns` **{Object}** `this`: to enable chaining
-
-**Example**
-
-```js
-mapper.alias('foo', 'bar');
-```
-
-### [.process](index.js#L159)
-
-Process a configuration object with the already configured `map` and `app`.
-
-**Params**
-
-* `config` **{Object}**: Configuration object to map to application methods.
-
-**Example**
-
-```js
-mapper.process(config);
 ```
 
 ## Related projects

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ mapper
   });
 ```
 
-### [.alias](index.js#L134)
+### [.alias](index.js#L143)
 
 Alias properties to methods on the `app`.
 
@@ -109,7 +109,7 @@ Alias properties to methods on the `app`.
 mapper.alias('foo', 'bar');
 ```
 
-### [.process](index.js#L150)
+### [.process](index.js#L159)
 
 Process a configuration object with the already configured `map` and `app`.
 

--- a/example/nested-configs-2.js
+++ b/example/nested-configs-2.js
@@ -1,0 +1,57 @@
+'use strict';
+
+var Base = require('base-methods');
+var MapConfig = require('../');
+
+/**
+ * Set up an example application class that stores related modules.
+ */
+
+function App () {
+  Base.call(this);
+  this.related = [];
+}
+Base.extend(App);
+
+App.prototype.addRelated = function(name) {
+  this.related.push(name);
+  return this;
+};
+
+/**
+ * Initialize the app.
+ */
+
+var app = new App();
+var pkg = require('../package.json');
+
+/**
+ * Create a configuration map to handle `related` object.
+ */
+
+var relatedConfig = MapConfig(app)
+  .map('list', function (list) {
+    if (!Array.isArray(list)) return;
+    // `this` is the app instance
+    list.forEach(function (item) {
+      this.addRelated(item);
+    }.bind(this));
+  });
+
+/**
+ * Create a configuration map to handle the `verb` object.
+ */
+
+var verbConfig = MapConfig(app)
+  .map('related', relatedConfig);
+
+/**
+ * Create a configuration map and process the package.json
+ * file, adding related modules to the `app` instance.
+ */
+
+var config = MapConfig(app)
+  .map('verb', verbConfig)
+  .process(pkg);
+
+console.log(app);

--- a/index.js
+++ b/index.js
@@ -23,6 +23,8 @@ function MapConfig(app, config) {
     return new MapConfig(app, config);
   }
 
+  define(this, 'isMapConfig', true);
+
   this.app = app || {};
   this.keys = [];
   this.aliases = {};
@@ -182,7 +184,23 @@ MapConfig.prototype.addKey = function(key, arr) {
 function isMapConfig(val) {
   return val
     && typeof val === 'object'
-    && typeof val.process === 'function';
+    && val.isMapConfig === true;
+}
+
+/**
+ * Define a property on an object.
+ *
+ * @param  {Object} `obj` Object to define property on.
+ * @param  {String} `prop` Property to define.
+ * @param  {*} `val` Value of property to define.
+ */
+
+function define(obj, prop, val) {
+  Object.defineProperty(obj, prop, {
+    enumerable: false,
+    configurable: true,
+    value: val
+  });
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -41,59 +41,6 @@ function MapConfig(app, config) {
 }
 
 /**
- * Add a key to the `.keys` array. May also be used to add an array of namespaced keys to the `.keys` array.
- * This is useful for mapping sub configs to a key in a parent config.
- *
- * ```js
- * mapper.addKey('foo');
- * console.log(mapper.keys);
- * //=> ['foo']
- *
- * var mapper1 = new MapConfig();
- * var mapper2 = new MapConfig();
- * mapper2.map('foo');
- * mapper2.map('bar');
- * mapper2.map('baz');
- *
- * mapper1.map('mapper2', function(config) {
- *   mapper2.process(config);
- * });
- * mapper1.addKey('mapper2', mapper2.keys);
- * console.log(mapper1.keys);
- * //=> ['mapper2.foo', 'mapper2.bar', 'mapper2.baz']
- * ```
- *
- * @param {String} `key` key to push onto `.keys`
- * @param {Array} `arr` Array of sub keys to push onto `.keys`
- * @return {Object} `this` for chaining
- * @api public
- */
-
-MapConfig.prototype.addKey = function(key, arr) {
-  var idx = this.keys.indexOf(key);
-  if (Array.isArray(arr)) {
-    if (idx === -1) {
-      this.keys = this.keys.concat(arr.map(function(val) {
-        return [key, val].join('.');
-      }));
-    } else {
-      this.keys.splice(idx, 1);
-      var vals = arr.map(function(val) {
-        return [key, val].join('.');
-      })
-      .filter(function(val) {
-        return this.keys.indexOf(val) === -1;
-      }.bind(this));
-
-      this.keys.push.apply(this.keys, vals);
-    }
-  } else if (idx === -1) {
-    this.keys.push(key);
-  }
-  return this;
-};
-
-/**
  * Map a properties to methods and/or functions.
  *
  * ```js
@@ -171,6 +118,66 @@ MapConfig.prototype.process = function(args) {
     }
   }
 };
+
+/**
+ * Add a key to the `.keys` array. May also be used to add an array of namespaced keys to the `.keys` array.
+ * This is useful for mapping sub configs to a key in a parent config.
+ *
+ * ```js
+ * mapper.addKey('foo');
+ * console.log(mapper.keys);
+ * //=> ['foo']
+ *
+ * var mapper1 = new MapConfig();
+ * var mapper2 = new MapConfig();
+ * mapper2.map('foo');
+ * mapper2.map('bar');
+ * mapper2.map('baz');
+ *
+ * mapper1.map('mapper2', function(config) {
+ *   mapper2.process(config);
+ * });
+ * mapper1.addKey('mapper2', mapper2.keys);
+ * console.log(mapper1.keys);
+ * //=> ['mapper2.foo', 'mapper2.bar', 'mapper2.baz']
+ * ```
+ *
+ * @param {String} `key` key to push onto `.keys`
+ * @param {Array} `arr` Array of sub keys to push onto `.keys`
+ * @return {Object} `this` for chaining
+ * @api public
+ */
+
+MapConfig.prototype.addKey = function(key, arr) {
+  var idx = this.keys.indexOf(key);
+  if (Array.isArray(arr)) {
+    if (idx === -1) {
+      this.keys = this.keys.concat(arr.map(function(val) {
+        return [key, val].join('.');
+      }));
+    } else {
+      this.keys.splice(idx, 1);
+      var vals = arr.map(function(val) {
+        return [key, val].join('.');
+      })
+      .filter(function(val) {
+        return this.keys.indexOf(val) === -1;
+      }.bind(this));
+
+      this.keys.push.apply(this.keys, vals);
+    }
+  } else if (idx === -1) {
+    this.keys.push(key);
+  }
+  return this;
+};
+
+/**
+ * Check if given value looks like an instance of `map-config`
+ *
+ * @param  {*} `val` Value to check
+ * @return {Boolean} `true` if instance of `map-config`
+ */
 
 function isMapConfig(val) {
   return val

--- a/index.js
+++ b/index.js
@@ -104,15 +104,24 @@ MapConfig.prototype.addKey = function(key, arr) {
  * ```
 
  * @param  {String} `key` property key to map.
- * @param  {Function} `fn` Optional function to call when a config has the given key.
+ * @param  {Function|Object} `val` Optional function to call when a config has the given key. May also pass another instance of MapConfig to be processed.
  * @return {Object} `this` to enable chaining
  * @api public
  */
 
 MapConfig.prototype.map = function(key, val) {
+  // allow passing another map-config object in as a value
+  if (isMapConfig(val)) {
+    this.map(key, function(config) {
+      return val.process(config);
+    });
+    return this.addKey(key, val.keys);
+  }
+
   if (typeof val !== 'function') {
     val = this.app[key];
   }
+
   this.config[key] = val;
   this.addKey(key);
   return this;
@@ -162,6 +171,12 @@ MapConfig.prototype.process = function(args) {
     }
   }
 };
+
+function isMapConfig(val) {
+  return val
+    && typeof val === 'object'
+    && typeof val.process === 'function';
+}
 
 /**
  * Exposes MapConfig

--- a/index.js
+++ b/index.js
@@ -48,9 +48,7 @@ function MapConfig(app, config) {
  * mapper.addKey('foo');
  * console.log(mapper.keys);
  * //=> ['foo']
- * ```
  *
- * ```
  * var mapper1 = new MapConfig();
  * var mapper2 = new MapConfig();
  * mapper2.map('foo');
@@ -61,6 +59,8 @@ function MapConfig(app, config) {
  *   mapper2.process(config);
  * });
  * mapper1.addKey('mapper2', mapper2.keys);
+ * console.log(mapper1.keys);
+ * //=> ['mapper2.foo', 'mapper2.bar', 'mapper2.baz']
  * ```
  *
  * @param {String} `key` key to push onto `.keys`

--- a/test.js
+++ b/test.js
@@ -257,7 +257,6 @@ describe('map-config', function() {
       var output = [];
       var app = {
         foo: function(config) {
-          console.log('foo', config);
           output.push('foo ' + config.baz);
         },
         bar: function(config) {

--- a/test.js
+++ b/test.js
@@ -207,6 +207,19 @@ describe('map-config', function() {
       assert.deepEqual(mapper1.keys, ['foo', 'bar', 'baz']);
       assert.deepEqual(mapper2.keys, ['mapper1.foo', 'mapper1.bar', 'mapper1.baz']);
     });
+
+    it('should add an array of mapped keys when a mapper is passed into `.map`.', function() {
+      var mapper1 = new MapConfig({});
+      mapper1.map('foo');
+      mapper1.map('bar');
+      mapper1.map('baz');
+
+      var mapper2 = new MapConfig({});
+      mapper2.map('mapper1', mapper1);
+
+      assert.deepEqual(mapper1.keys, ['foo', 'bar', 'baz']);
+      assert.deepEqual(mapper2.keys, ['mapper1.foo', 'mapper1.bar', 'mapper1.baz']);
+    });
   });
 
   describe('map', function() {
@@ -238,6 +251,36 @@ describe('map-config', function() {
       mapper.process(config);
 
       assert.deepEqual(output, ['foo beep']);
+    });
+
+    it('should call a child mapper when passed through `.map`', function() {
+      var output = [];
+      var app = {
+        foo: function(config) {
+          console.log('foo', config);
+          output.push('foo ' + config.baz);
+        },
+        bar: function(config) {
+          output.push('bar ' + config.bang);
+        }
+      };
+
+      var config = {
+        child: {
+          foo: {baz: 'beep'},
+          bar: {bang: 'boop'}
+        }
+      };
+
+      var mapper1 = new MapConfig(app)
+        .map('foo')
+        .map('bar');
+
+      var mapper2 = new MapConfig()
+        .map('child', mapper1);
+
+      mapper2.process(config);
+      assert.deepEqual(output, ['foo beep', 'bar boop']);
     });
 
     it('should not map anything when config is empty from `.map`', function() {


### PR DESCRIPTION
Allows passing map-config instances directly into `.map` instead of having to wrap them with a function and calling `.process`. This also sets up the namespaced keys correctly.
